### PR TITLE
Added input field to specify the wait time between execution steps

### DIFF
--- a/index-dev.html
+++ b/index-dev.html
@@ -37,6 +37,7 @@
             <p><input type="button" value="Run" id="run"></p>
             <p><input type="button" value="Step" id="step"></p>
           </div>
+          <p><label for="wait_time">Wait time: </label><input type="number" value="100" id="wait_time" placeholder="Wait time" /></p>
         </div>
         
       </div>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <p><input type="button" value="Run" id="run"></p>
             <p><input type="button" value="Step" id="step"></p>
           </div>
+        <p><label for="wait_time">Wait time: </label><input type="number" value="100" id="wait_time" placeholder="Wait time" /></p>
         </div>
         
       </div>

--- a/src/main/scala/ui/Main.scala
+++ b/src/main/scala/ui/Main.scala
@@ -12,6 +12,7 @@ object Main extends js.JSApp {
   
   var ms = MachineState()
   var running = false
+  var wait_time = 100
   val memoryTable = new MachineWordTable(16, true)
   val registerTable = new MachineWordTable(1, true, "GPRs")
   
@@ -23,7 +24,7 @@ object Main extends js.JSApp {
     if (ms.cycleState == Halted)
       running = false
     else
-      g.setTimeout(run _, 500)
+      g.setTimeout(run _, wait_time)
   }
 
   def updateLights() {
@@ -127,13 +128,13 @@ object Main extends js.JSApp {
       if (!running) {
         ms = ms.withClearedCPU
         updateUI()
-        g.setTimeout(run _, 500)
+        g.setTimeout(run _, wait_time)
       }
     }
     
     g.document.getElementById("run").onclick = () => {
       if (!running) {
-        g.setTimeout(run _, 500)
+        g.setTimeout(run _, wait_time)
       }
     }
     
@@ -143,6 +144,11 @@ object Main extends js.JSApp {
         updateUI()
       }
     }
-    
+
+    val field = g.document.getElementById("wait_time")
+
+    field.onchange = () => {
+      wait_time = g.parseInt(field.value).asInstanceOf[Int]
+    }
   }
 }

--- a/src/main/scala/ui/Main.scala
+++ b/src/main/scala/ui/Main.scala
@@ -12,7 +12,7 @@ object Main extends js.JSApp {
   
   var ms = MachineState()
   var running = false
-  var wait_time = 100
+  var wait_time = 500
   val memoryTable = new MachineWordTable(16, true)
   val registerTable = new MachineWordTable(1, true, "GPRs")
   


### PR DESCRIPTION
This pull request adds a field to specify the time between execution steps.

Since it takes quite some time to run looping programs, the default waiting time is too long sometimes.

(If an invalid value is given in the input field, setTimeout defaults to 0.)